### PR TITLE
feat: [CSA-4488] allow extra scopes to be passed to initializer

### DIFF
--- a/lib/omniauth/strategies/class_link.rb
+++ b/lib/omniauth/strategies/class_link.rb
@@ -19,7 +19,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          params[:scope] = [:email, :profile]
+          params[:scope] = (params[:scope] || []).union([:email, :profile])
           params[:response_type] = :code
         end
       end


### PR DESCRIPTION
This allows custom scopes to be passed over to the classlink via the omniauth classlink strategy. The gem itself just hardcodes scopes to `email` and `profile` which isn't enough for our use case. 